### PR TITLE
release: merge v1.2.0-rc a main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## [v1.1.0] - 2026-04-06
+### Added
+- Separación de responsabilidades en el backend:
+  - Creación de **controladores** para usuarios y tareas.
+  - Refactorización de **rutas** para delegar la lógica a los controladores.
+- Estructura modular del proyecto:
+  - `src/routes/users.routes.js`
+  - `src/routes/tasks.routes.js`
+  - `src/controllers/users.controller.js`
+  - `src/controllers/tasks.controller.js`
+- Archivo principal `app.js` actualizado para usar las nuevas rutas.
+
+### Changed
+- Las rutas ya no contienen lógica directa, ahora solo direccionan hacia los controladores.
+
+### Version
+- `v1.0.0` → Inicio del backend con servidor básico y rutas directas.
+- `v1.1.0` → Separación de rutas y creación de controladores.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,26 @@
 # Changelog
 
-## [v1.1.0] - 2026-04-06
+## [v1.2.0] - 2026-04-06
 ### Added
-- Separación de responsabilidades en el backend:
-  - Creación de **controladores** para usuarios y tareas.
-  - Refactorización de **rutas** para delegar la lógica a los controladores.
-- Estructura modular del proyecto:
-  - `src/routes/users.routes.js`
-  - `src/routes/tasks.routes.js`
-  - `src/controllers/users.controller.js`
-  - `src/controllers/tasks.controller.js`
-- Archivo principal `app.js` actualizado para usar las nuevas rutas.
+- Implementación de **CRUD completo** en usuarios y tareas:
+  - Registrar nuevos usuarios y tareas (POST).
+  - Consultar todos los usuarios/tareas (GET).
+  - Consultar un usuario/tarea específico (GET /:id).
+  - Actualizar información completa (PUT).
+  - Actualizar información parcial (PATCH).
+  - Eliminar usuarios/tareas (DELETE).
+- Nuevas rutas en Express para usuarios y tareas:
+  - `/api/users` y `/api/tasks` con soporte para GET, POST, PUT, PATCH, DELETE.
+- Controladores actualizados para manejar validaciones y códigos de estado HTTP adecuados:
+  - 200 → OK
+  - 201 → Created
+  - 500 → Error del servidor
 
 ### Changed
-- Las rutas ya no contienen lógica directa, ahora solo direccionan hacia los controladores.
+- Los modelos ahora simulan operaciones CRUD devolviendo mensajes descriptivos, en lugar de lógica de base de datos.
+- Se amplió la separación de responsabilidades: rutas → controladores → modelos.
 
 ### Version
 - `v1.0.0` → Inicio del backend con servidor básico y rutas directas.
 - `v1.1.0` → Separación de rutas y creación de controladores.
+- `v1.2.0` → CRUD completo con soporte para PATCH en usuarios y tareas.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "nodemon": "^3.1.14"
       }
     },
     "node_modules/accepts": {
@@ -22,6 +23,37 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -45,6 +77,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/bytes": {
@@ -80,6 +134,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/content-disposition": {
@@ -250,6 +327,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -284,6 +372,19 @@
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -329,6 +430,17 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -338,6 +450,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -396,6 +516,11 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -407,6 +532,44 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-promise": {
@@ -464,6 +627,20 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -475,6 +652,41 @@
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {
@@ -524,6 +736,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -535,6 +758,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
     },
     "node_modules/qs": {
       "version": "6.15.0",
@@ -572,6 +800,17 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -591,6 +830,17 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.1",
@@ -708,6 +958,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -716,12 +977,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
       }
     },
     "node_modules/type-is": {
@@ -736,6 +1027,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,15 @@
   "main": "app.js",
   "type": "module",
   "scripts": {
-    "start": "node src/app.js"
+    "start": "node src/app.js",
+    "dev": "nodemon src/app.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "nodemon": "^3.1.14"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -7,10 +7,10 @@ const PORT = 3000;
 
 // Ruta raíz
 app.get('/', (req, res) => {
-  res.send('Bienvenido al sistema de gestión de tareas academicas');
+  res.send('Bienvenido al sistema de gestión académica');
 });
 
-// Rutas
+// Usar rutas
 app.use('/users', userRoutes);
 app.use('/tasks', taskRoutes);
 

--- a/src/controllers/tasks.controller.js
+++ b/src/controllers/tasks.controller.js
@@ -1,0 +1,9 @@
+// GET /tasks
+export const getTasks = (req, res) => {
+  res.send('Aquí se listarán las tareas');
+};
+
+// POST /tasks
+export const createTask = (req, res) => {
+  res.send('Aquí se creará una tarea');
+};

--- a/src/controllers/tasks.controller.js
+++ b/src/controllers/tasks.controller.js
@@ -1,9 +1,64 @@
-// GET /tasks
+import { getAllTasks, getTask, addTask, updateTask, patchTask, deleteTask } from '../models/tasks.model.js';
+
+// Consultar todas las tareas
 export const getTasks = (req, res) => {
-  res.send('Aquí se listarán las tareas');
+  try {
+    const tasks = getAllTasks();
+    res.status(200).json(tasks);
+  } catch {
+    res.status(500).json({ message: 'Error al obtener tareas' });
+  }
 };
 
-// POST /tasks
+// Consultar una tarea específica
+export const getTaskById = (req, res) => {
+  try {
+    const task = getTask(req.params.id);
+    res.status(200).json(task);
+  } catch {
+    res.status(500).json({ message: 'Error al obtener tarea' });
+  }
+};
+
+// Registrar una nueva tarea
 export const createTask = (req, res) => {
-  res.send('Aquí se creará una tarea');
+  try {
+    if (!req.body.titulo) {
+      return res.status(400).json({ message: 'El título es obligatorio' });
+    }
+    const newTask = addTask({ titulo: req.body.titulo });
+    res.status(201).json({ message: 'Tarea creada', task: newTask });
+  } catch {
+    res.status(500).json({ message: 'Error al crear tarea' });
+  }
+};
+
+// Actualizar información de una tarea
+export const updateTaskById = (req, res) => {
+  try {
+    const updated = updateTask(req.params.id, req.body);
+    res.status(200).json({ message: 'Tarea actualizada', task: updated });
+  } catch {
+    res.status(500).json({ message: 'Error al actualizar tarea' });
+  }
+};
+
+// PATCH → actualización parcial
+export const patchTaskById = async (req, res) => {
+  try {
+    const patched = await patchTask(req.params.id, req.body);
+    res.status(200).json({ message: 'Tarea actualizada parcialmente', task: patched });
+  } catch {
+    res.status(500).json({ message: 'Error al actualizar parcialmente la tarea' });
+  }
+};
+
+// Eliminar una tarea
+export const deleteTaskById = (req, res) => {
+  try {
+    const deleted = deleteTask(req.params.id);
+    res.status(200).json({ message: 'Tarea eliminada', task: deleted });
+  } catch {
+    res.status(500).json({ message: 'Error al eliminar tarea' });
+  }
 };

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,0 +1,9 @@
+// GET /users
+export const getUsers = (req, res) => {
+  res.send('Aquí se listarán los usuarios');
+};
+
+// POST /users
+export const createUser = (req, res) => {
+  res.send('Aquí se creará un usuario');
+};

--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -1,9 +1,64 @@
-// GET /users
+import { getAllUsers, getUser, addUser, updateUser, patchUser, deleteUser } from '../models/users.model.js';
+
+// Consultar todos los usuarios
 export const getUsers = (req, res) => {
-  res.send('Aquí se listarán los usuarios');
+  try {
+    const users = getAllUsers();
+    res.status(200).json(users);
+  } catch {
+    res.status(500).json({ message: 'Error al obtener usuarios' });
+  }
 };
 
-// POST /users
+// Consultar un usuario específico
+export const getUserById = (req, res) => {
+  try {
+    const user = getUser(req.params.id);
+    res.status(200).json(user);
+  } catch {
+    res.status(500).json({ message: 'Error al obtener usuario' });
+  }
+};
+
+// Registrar un nuevo usuario
 export const createUser = (req, res) => {
-  res.send('Aquí se creará un usuario');
+  try {
+    if (!req.body.nombre) {
+      return res.status(400).json({ message: 'El nombre es obligatorio' });
+    }
+    const newUser = addUser({ nombre: req.body.nombre });
+    res.status(201).json({ message: 'Usuario creado', user: newUser });
+  } catch {
+    res.status(500).json({ message: 'Error al crear usuario' });
+  }
+};
+
+// Actualizar información de un usuario
+export const updateUserById = (req, res) => {
+  try {
+    const updated = updateUser(req.params.id, req.body);
+    res.status(200).json({ message: 'Usuario actualizado', user: updated });
+  } catch {
+    res.status(500).json({ message: 'Error al actualizar usuario' });
+  }
+};
+
+// PATCH → actualización parcial
+export const patchUserById = async (req, res) => {
+  try {
+    const patched = await patchUser(req.params.id, req.body);
+    res.status(200).json({ message: 'Usuario actualizado parcialmente', user: patched });
+  } catch {
+    res.status(500).json({ message: 'Error al actualizar parcialmente el usuario' });
+  }
+};
+
+// Eliminar un usuario
+export const deleteUserById = (req, res) => {
+  try {
+    const deleted = deleteUser(req.params.id);
+    res.status(200).json({ message: 'Usuario eliminado', user: deleted });
+  } catch {
+    res.status(500).json({ message: 'Error al eliminar usuario' });
+  }
 };

--- a/src/models/tasks.model.js
+++ b/src/models/tasks.model.js
@@ -1,0 +1,26 @@
+// Modelo de Tareas
+
+export const getAllTasks = () => {
+  return { message: "Consulta de todas las tareas realizada" };
+};
+
+export const getTask = (id) => {
+  return { message: `Consulta de la tarea con id ${id} realizada` };
+};
+
+export const addTask = (task) => {
+  return { message: `Tarea '${task.titulo}' registrada correctamente` };
+};
+
+export const updateTask = (id, data) => {
+  return { message: `Tarea con id ${id} actualizada completamente` };
+};
+
+// PATCH → actualización parcial
+export const patchTask = (id, data) => {
+  return { message: `Tarea con id ${id} actualizada parcialmente` };
+};
+
+export const deleteTask = (id) => {
+  return { message: `Tarea con id ${id} eliminada correctamente` };
+};

--- a/src/models/users.model.js
+++ b/src/models/users.model.js
@@ -1,0 +1,26 @@
+// Modelo de Usuarios - Simulación según guía
+
+export const getAllUsers = () => {
+  return { message: "Consulta de todos los usuarios realizada" };
+};
+
+export const getUser = (id) => {
+  return { message: `Consulta del usuario con id ${id} realizada` };
+};
+
+export const addUser = (user) => {
+  return { message: `Usuario ${user.nombre} registrado correctamente` };
+};
+
+export const updateUser = (id, data) => {
+  return { message: `Usuario con id ${id} actualizado completamente` };
+};
+
+// PATCH → actualización parcial
+export const patchUser = (id, data) => {
+  return { message: `Usuario con id ${id} actualizado parcialmente` };
+};
+
+export const deleteUser = (id) => {
+  return { message: `Usuario con id ${id} eliminado correctamente` };
+};

--- a/src/routes/tasks.routes.js
+++ b/src/routes/tasks.routes.js
@@ -1,12 +1,31 @@
 import { Router } from 'express';
-import { getTasks, createTask } from '../controllers/tasks.controller.js';
+import {
+  getTasks,
+  getTaskById,
+  createTask,
+  updateTaskById,
+  patchTaskById,
+  deleteTaskById
+} from '../controllers/tasks.controller.js';
 
 const router = Router();
 
-// GET /tasks → Devuelve un mensaje indicando que se listarán las tareas
+// Consultar todas las tareas
 router.get('/', getTasks);
 
-// POST /tasks → Mensaje indicando que se creará una tarea
+// Consultar una tarea específica
+router.get('/:id', getTaskById);
+
+// Registrar una nueva tarea
 router.post('/', createTask);
+
+// Actualizar información de una tarea
+router.put('/:id', updateTaskById);
+
+// Actualizar informacion de una tarea parcialmente
+router.patch('/:id', patchTaskById);
+
+// Eliminar una tarea
+router.delete('/:id', deleteTaskById);
 
 export default router;

--- a/src/routes/tasks.routes.js
+++ b/src/routes/tasks.routes.js
@@ -1,14 +1,12 @@
 import { Router } from 'express';
+import { getTasks, createTask } from '../controllers/tasks.controller.js';
+
 const router = Router();
 
-// GET /tasks
-router.get('/', (req, res) => {
-  res.send('Aquí se listarán las tareas');
-});
+// GET /tasks → Devuelve un mensaje indicando que se listarán las tareas
+router.get('/', getTasks);
 
-// POST /tasks
-router.post('/', (req, res) => {
-  res.send('Aquí se creará una tarea');
-});
+// POST /tasks → Mensaje indicando que se creará una tarea
+router.post('/', createTask);
 
 export default router;

--- a/src/routes/users.routes.js
+++ b/src/routes/users.routes.js
@@ -1,12 +1,31 @@
 import { Router } from 'express';
-import { getUsers, createUser } from '../controllers/users.controller.js';
+import {
+  getUsers,
+  getUserById,
+  createUser,
+  updateUserById,
+  patchUserById,
+  deleteUserById
+} from '../controllers/users.controller.js';
 
 const router = Router();
 
-// GET /users → Devuelve un mensaje indicando que se listarán los usuarios
+// Consultar todos los usuarios
 router.get('/', getUsers);
 
-// POST /users → Mensaje indicando que se creará un usuario
+// Consultar un usuario específico
+router.get('/:id', getUserById);
+
+// Registrar un nuevo usuario
 router.post('/', createUser);
+
+// Actualizar información de un usuario
+router.put('/:id', updateUserById);
+
+// Actualizar informacion de un usuario parcialmente
+router.patch('/:id', patchUserById);
+
+// Eliminar un usuario
+router.delete('/:id', deleteUserById);
 
 export default router;

--- a/src/routes/users.routes.js
+++ b/src/routes/users.routes.js
@@ -1,14 +1,12 @@
 import { Router } from 'express';
+import { getUsers, createUser } from '../controllers/users.controller.js';
+
 const router = Router();
 
-// GET /users
-router.get('/', (req, res) => {
-  res.send('Aquí se listarán los usuarios');
-});
+// GET /users → Devuelve un mensaje indicando que se listarán los usuarios
+router.get('/', getUsers);
 
-// POST /users
-router.post('/', (req, res) => {
-  res.send('Aquí se creará un usuario');
-});
+// POST /users → Mensaje indicando que se creará un usuario
+router.post('/', createUser);
 
 export default router;


### PR DESCRIPTION
Este PR integra la versión candidata v1.2.0-rc desde la rama release hacia main, consolidando las nuevas funcionalidades como versión estable.

### Cambios incluidos
- Implementación de CRUD completo en usuarios y tareas:
  - Registrar (POST)
  - Consultar todos y específicos (GET)
  - Actualizar completo (PUT)
  - Actualizar parcial (PATCH)
  - Eliminar (DELETE)
- Separación de responsabilidades en el backend:
  - Rutas → Controladores → Modelos
- Modelos simulados según guía del SENA, preparados para futura conexión con base de datos.
- Controladores con validaciones y códigos de estado HTTP adecuados (200, 201, 500).
- Actualización del CHANGELOG.md a la versión v1.2.0.

### Impacto
- `main` quedará actualizado con la versión estable v1.2.0.
- Se garantiza que el backend está organizado y listo para futuras integraciones con SQL.
- Cumple con la guía de aprendizaje y buenas prácticas de desarrollo backend.
