### PR TITLE
feat(utils): estandarizar respuestas 401 no autenticado

### DIFF
--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -1,4 +1,5 @@
-import { verifyJWT, catchAsync } from '../utils/index.js';
+import { verifyJWT, catchAsync, buildUnauthorizedError } from '../utils/index.js';
+import { UserModel } from '../models/index.js';
 import "dotenv/config";
 
 export const validateToken = catchAsync(async (req, res, next) => {
@@ -11,27 +12,27 @@ export const validateToken = catchAsync(async (req, res, next) => {
 
     // 2. Si no hay token, lanzamos error al middleware global
     if (!token) {
-        const error = new Error('Acceso denegado: No se proporcionó un token');
-        error.statusCode = 401;
-        return next(error);
+        return next(buildUnauthorizedError('No se proporcionó token de acceso'));
     }
 
     // 3. Verificar token con utilidad
-    const result = verifyJWT(token);
+    const result = verifyJWT(token, process.env.JWT_SECRET);
 
     if (!result.valid) {
-        const error = new Error(result.message);
-        error.statusCode = 401;
-        return next(error);
+        return next(buildUnauthorizedError(result.message));
     }
 
     const decoded = result.decoded;
 
     // 4. Verificar que sea tipo access
     if (decoded.type !== 'access') {
-        const error = new Error('Acceso denegado: El token no es válido para esta operación');
-        error.statusCode = 401;
-        return next(error);
+        return next(buildUnauthorizedError('El token no es válido para esta operación'));
+    }
+
+    const dbUser = await UserModel.findByIdWithTokenVersion(decoded.userId);
+
+    if (!dbUser || (decoded.tokenVersion ?? -1) !== dbUser.token_version) {
+        return next(buildUnauthorizedError('La sesión no es válida o ha sido cerrada'));
     }
 
     // 5. Adjuntar la info del usuario al request (req.user)

--- a/src/middlewares/rbac.middleware.js
+++ b/src/middlewares/rbac.middleware.js
@@ -1,5 +1,5 @@
 import { RoleModel } from '../models/index.js';
-import { buildError, catchAsync } from '../utils/index.js';
+import { buildError, buildUnauthorizedError, catchAsync } from '../utils/index.js';
 
 export const checkPermission = (requiredPermission) =>
   catchAsync(async (req, res, next) => {
@@ -7,9 +7,7 @@ export const checkPermission = (requiredPermission) =>
 
     if (!userId) {
       return next(
-        buildError('No autenticado', 401, [
-          'No se encontró información del usuario en la solicitud',
-        ])
+        buildUnauthorizedError('No se encontró información del usuario en la solicitud')
       );
     }
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,3 @@
 export { catchAsync } from './catchAsync.js';
 export { generateToken, verifyJWT } from './jwt.handler.js';
-export { successResponse, errorResponse, buildError } from './response.handler.js';
+export { successResponse, errorResponse, buildError, buildUnauthorizedError } from './response.handler.js';

--- a/src/utils/response.handler.js
+++ b/src/utils/response.handler.js
@@ -48,3 +48,14 @@ export const buildError = (message, statusCode, details = []) => {
     // Retorna el error para que lo procese el middleware
     return err;
 };
+
+/**
+    Crea un error 401 estandarizado para rutas protegidas
+**/
+export const buildUnauthorizedError = (detail = "No autorizado. Debe iniciar sesión para acceder a este recurso.") => {
+    return buildError(
+        "No autorizado. Debe iniciar sesión para acceder a este recurso.",
+        401,
+        [detail]
+    );
+};


### PR DESCRIPTION
## Descripción del Cambio
*Este PR introduce una refactorización profunda en el flujo de gestión de usuarios y centraliza el manejo de respuestas de autenticación erróneas. Esto corrige el bug de inserción con password_hash nulo y previene inconsistencias con roles inexistentes en el catálogo real.*

## Tipo de Cambio
- [ ] **feat**: Nueva funcionalidad.
- [X] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #38 

---

## Checklist de Calidad Universal
- [X] **Sincronización:** He actualizado mi rama con `origin/develop` y resolví conflictos.
- [X] **Limpieza:** Sin `console.log`, comentarios de prueba o archivos `.env`.
- [X] **Estándares:** Uso de JSDoc para funciones y nombres de variables en camelCase.

### Validación BACKEND (Si aplica)
- [X] **Endpoints:** He probado las rutas en Postman/Thunder Client y retornan el código HTTP correcto.
- [X] **Validación:** Se implementó manejo de errores (try/catch) y validación de datos de entrada.
- [X] **Modelos:** Los cambios en la base de datos o modelos fueron comunicados al equipo.

---

## Evidencia de Trabajo
*Adjunta un screenshot (Frontend) o un snippet del JSON de respuesta (Backend).*

<img width="1678" height="2116" alt="SNIPPET1" src="https://github.com/user-attachments/assets/532b81ce-b378-4b96-9f96-f968f1c89c86" />

<img width="1664" height="1356" alt="SNIPPET2" src="https://github.com/user-attachments/assets/bffb787f-cc16-414b-ab23-0d102cee7171" />

## Análisis de Impacto
*¿Este cambio requiere que mis compañeros actualicen algo? (Ej: "Deben ejecutar npm install" o "Cambió la URL de la API").*

El esquema de validación para la creación de usuarios (src/schemas/users.schema.js) ahora exige de manera obligatoria el campo password.

El campo role enviado en el body de la petición ahora se normaliza automáticamente a mayúsculas y es restrictivo frente al catálogo de la base de datos (ADMIN, SUPERVISOR, USER). Cualquier otro valor provocará un error de validación 400 Bad Request.