### PR TITLE
Feat/add role methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -408,3 +408,56 @@
     - extrae códigos con `permissions.map(permission => permission.code)`
     - valida acceso contra `requiredPermission` usando el arreglo de códigos.
   - Se conserva `req.user.permissions` con estructura completa para trazabilidad.
+
+-----------------------------------------------------------------------------------------------------------------------------
+
+## [v1.5.7] - 2026-05-16
+
+### Added
+- Implementación de CRUD extendido para roles con soporte completo en capa HTTP:
+  - `POST /roles`
+  - `PUT /roles/:id`
+  - `PATCH /roles/:id`
+  - `DELETE /roles/:id`
+- Nuevo endpoint para consultar permisos de un rol específico:
+  - `GET /roles/:id/permissions`
+- Nuevo método en modelo de roles:
+  - `findPermissionsByRoleId(roleId)` para resolver permisos por rol desde `role_permissions`.
+- Exportación de `getRolePermissionsById` en `src/controllers/index.js`.
+
+### Changed
+- **src/schemas/roles.schema.js**
+  - Se corrigió el formato de validación de permisos a convención real:
+    - de `recurso:accion`
+    - a `recurso.accion`.
+  - Se añadieron/ajustaron esquemas para update de roles:
+    - `roleUpdateSchema`
+    - `rolePatchSchema`
+  - Ambos esquemas permiten actualización parcial (estilo patch-like), incluyendo `permissions`.
+- **src/routes/roles.routes.js**
+  - Se ampliaron rutas protegidas de roles con `validateToken` + `checkPermission(...)`:
+    - altas, edición, eliminación y consulta de permisos por rol.
+  - Se mantuvo `POST /roles/manage` para validación guiada por schema.
+- **src/models/roles.model.js**
+  - Se agregó `updateWithPermissions(id, roleData)` con transacción:
+    - actualiza datos básicos del rol (`name`, `description`) cuando se envían,
+    - sincroniza permisos en `role_permissions` (reemplazo controlado),
+    - `commit/rollback` para consistencia transaccional.
+  - Se conservan métodos previos de consulta y creación con permisos.
+- **src/controllers/roles.controller.js**
+  - `createRole` valida códigos de permisos contra BD antes de persistir.
+  - `updateRoleById` y `patchRoleById` ahora aceptan `permissions`:
+    - validan existencia de códigos,
+    - convierten códigos a IDs,
+    - actualizan rol y relaciones en una operación transaccional.
+  - Se agregó `getRolePermissionsById` para retornar permisos de un rol por ID.
+  - Se mantuvo validación robusta de `id` y control de duplicados por nombre.
+
+### Fixed
+- Error de validación por formato de permisos no alineado con los datos reales (`recurso:accion` vs `recurso.accion`).
+- Error al actualizar roles cuando no se enviaba `name` en `PUT`.
+- Restricción funcional que impedía actualizar permisos mediante `PUT/PATCH`.
+- Omisión de endpoint dedicado para consultar permisos por rol.
+
+### Notes
+- El módulo de roles queda alineado con la arquitectura existente (routes → controllers → models + schemas + middlewares).

--- a/src/controllers/index.js
+++ b/src/controllers/index.js
@@ -1,5 +1,14 @@
 export { loginJWT, refreshJWT, logout } from './auth.controller.js';
-export { getRoles, getRoleById, manageRole } from './roles.controller.js';
+export {
+  getRoles,
+  getRoleById,
+  getRolePermissionsById,
+  createRole,
+  updateRoleById,
+  patchRoleById,
+  deleteRoleById,
+  manageRole,
+} from './roles.controller.js';
 export {
   getTasks,
   getTaskById,

--- a/src/controllers/roles.controller.js
+++ b/src/controllers/roles.controller.js
@@ -1,6 +1,11 @@
 import { successResponse, buildError, catchAsync } from '../utils/index.js';
 import { RoleModel } from '../models/index.js';
 
+const parseRoleId = (id) => {
+    const parsedId = Number(id);
+    return Number.isInteger(parsedId) && parsedId > 0 ? parsedId : null;
+};
+
 // Consultar todos los roles
 export const getRoles = catchAsync(async (req, res, next) => {
     const roles = await RoleModel.findAll();
@@ -10,9 +15,9 @@ export const getRoles = catchAsync(async (req, res, next) => {
 // Consultar un rol específico
 export const getRoleById = catchAsync(async (req, res, next) => {
     const { id } = req.params;
-    const parsedId = Number(id);
+    const parsedId = parseRoleId(id);
 
-    if (!Number.isInteger(parsedId) || parsedId <= 0) {
+    if (!parsedId) {
         return next(buildError("ID de rol inválido", 400, ["El parámetro id debe ser un número entero positivo"]));
     }
 
@@ -23,6 +28,205 @@ export const getRoleById = catchAsync(async (req, res, next) => {
     }
 
     return successResponse(res, 200, `Rol con ID ${id} encontrado exitosamente`, role);
+});
+
+// Consultar permisos de un rol específico
+export const getRolePermissionsById = catchAsync(async (req, res, next) => {
+    const { id } = req.params;
+    const parsedId = parseRoleId(id);
+
+    if (!parsedId) {
+        return next(buildError("ID de rol inválido", 400, ["El parámetro id debe ser un número entero positivo"]));
+    }
+
+    const role = await RoleModel.findById(parsedId);
+
+    if (!role) {
+        return next(buildError("Rol no encontrado", 404, [`No se encontró ningún rol con el ID ${id}`]));
+    }
+
+    const permissions = await RoleModel.findPermissionsByRoleId(parsedId);
+
+    return successResponse(
+        res,
+        200,
+        `Permisos del rol con ID ${id} obtenidos exitosamente`,
+        permissions
+    );
+});
+
+// Crear un nuevo rol
+export const createRole = catchAsync(async (req, res, next) => {
+    const { name, description, permissions } = req.body;
+
+    const existingRole = await RoleModel.findByName(name);
+    if (existingRole) {
+        return next(buildError("Rol duplicado", 409, [`Ya existe un rol con el nombre '${name}'`]));
+    }
+
+    const foundPermissions = await RoleModel.findPermissionsByCodes(permissions);
+    const foundCodes = new Set(foundPermissions.map((permission) => permission.code));
+    const missingPermissions = permissions.filter((code) => !foundCodes.has(code));
+
+    if (missingPermissions.length > 0) {
+        return next(
+            buildError(
+                "Permisos inválidos",
+                400,
+                [`No existen los siguientes permisos: ${missingPermissions.join(", ")}`]
+            )
+        );
+    }
+
+    const role = await RoleModel.createWithPermissions({
+        name,
+        description: description ?? null,
+        permissions: foundPermissions.map((permission) => permission.id),
+    });
+
+    return successResponse(res, 201, "Rol creado exitosamente", role);
+});
+
+// Actualizar completamente un rol (PUT)
+export const updateRoleById = catchAsync(async (req, res, next) => {
+    const { id } = req.params;
+    const parsedId = parseRoleId(id);
+
+    if (!parsedId) {
+        return next(buildError("ID de rol inválido", 400, ["El parámetro id debe ser un número entero positivo"]));
+    }
+
+    const roleData = req.body;
+
+    if (Object.keys(roleData).length === 0) {
+        return next(buildError("Error al actualizar rol", 400, ["Debes enviar al menos un campo para actualizar"]));
+    }
+
+    const foundRole = await RoleModel.findById(parsedId);
+    if (!foundRole) {
+        return next(buildError("Error al actualizar rol", 404, [`No se encontró el rol con el ID ${id}`]));
+    }
+
+    if (roleData.name && roleData.name !== foundRole.name) {
+        const existingRole = await RoleModel.findByName(roleData.name);
+        if (existingRole && existingRole.id !== parsedId) {
+            return next(buildError("Rol duplicado", 409, [`Ya existe un rol con el nombre '${roleData.name}'`]));
+        }
+    }
+
+    let permissionIds;
+    if (Object.prototype.hasOwnProperty.call(roleData, "permissions")) {
+        const foundPermissions = await RoleModel.findPermissionsByCodes(roleData.permissions);
+        const foundCodes = new Set(foundPermissions.map((permission) => permission.code));
+        const missingPermissions = roleData.permissions.filter((code) => !foundCodes.has(code));
+
+        if (missingPermissions.length > 0) {
+            return next(
+                buildError(
+                    "Permisos inválidos",
+                    400,
+                    [`No existen los siguientes permisos: ${missingPermissions.join(", ")}`]
+                )
+            );
+        }
+
+        permissionIds = foundPermissions.map((permission) => permission.id);
+    }
+
+    const updatePayload = {};
+    if (Object.prototype.hasOwnProperty.call(roleData, "name")) {
+        updatePayload.name = roleData.name;
+    }
+    if (Object.prototype.hasOwnProperty.call(roleData, "description")) {
+        updatePayload.description = roleData.description;
+    }
+    if (Object.prototype.hasOwnProperty.call(roleData, "permissions")) {
+        updatePayload.permissions = permissionIds;
+    }
+
+    const updated = await RoleModel.updateWithPermissions(parsedId, updatePayload);
+
+    return successResponse(res, 200, `Rol con ID ${id} actualizado exitosamente (PUT)`, updated);
+});
+
+// Actualización parcial de un rol (PATCH)
+export const patchRoleById = catchAsync(async (req, res, next) => {
+    const { id } = req.params;
+    const parsedId = parseRoleId(id);
+
+    if (!parsedId) {
+        return next(buildError("ID de rol inválido", 400, ["El parámetro id debe ser un número entero positivo"]));
+    }
+
+    const roleData = req.body;
+
+    if (Object.keys(roleData).length === 0) {
+        return next(buildError("Error al editar rol", 400, ["Debes enviar al menos un campo para actualizar"]));
+    }
+
+    const foundRole = await RoleModel.findById(parsedId);
+    if (!foundRole) {
+        return next(buildError("Rol no encontrado", 404, [`No se encontró el rol con el ID ${id}`]));
+    }
+
+    if (roleData.name && roleData.name !== foundRole.name) {
+        const existingRole = await RoleModel.findByName(roleData.name);
+        if (existingRole && existingRole.id !== parsedId) {
+            return next(buildError("Rol duplicado", 409, [`Ya existe un rol con el nombre '${roleData.name}'`]));
+        }
+    }
+
+    let permissionIds;
+    if (Object.prototype.hasOwnProperty.call(roleData, "permissions")) {
+        const foundPermissions = await RoleModel.findPermissionsByCodes(roleData.permissions);
+        const foundCodes = new Set(foundPermissions.map((permission) => permission.code));
+        const missingPermissions = roleData.permissions.filter((code) => !foundCodes.has(code));
+
+        if (missingPermissions.length > 0) {
+            return next(
+                buildError(
+                    "Permisos inválidos",
+                    400,
+                    [`No existen los siguientes permisos: ${missingPermissions.join(", ")}`]
+                )
+            );
+        }
+
+        permissionIds = foundPermissions.map((permission) => permission.id);
+    }
+
+    const patchPayload = {};
+    if (Object.prototype.hasOwnProperty.call(roleData, "name")) {
+        patchPayload.name = roleData.name;
+    }
+    if (Object.prototype.hasOwnProperty.call(roleData, "description")) {
+        patchPayload.description = roleData.description;
+    }
+    if (Object.prototype.hasOwnProperty.call(roleData, "permissions")) {
+        patchPayload.permissions = permissionIds;
+    }
+
+    const patched = await RoleModel.updateWithPermissions(parsedId, patchPayload);
+
+    return successResponse(res, 200, `Rol con ID ${id} actualizado exitosamente (PATCH)`, patched);
+});
+
+// Eliminar un rol
+export const deleteRoleById = catchAsync(async (req, res, next) => {
+    const { id } = req.params;
+    const parsedId = parseRoleId(id);
+
+    if (!parsedId) {
+        return next(buildError("ID de rol inválido", 400, ["El parámetro id debe ser un número entero positivo"]));
+    }
+
+    const deleted = await RoleModel.delete(parsedId);
+
+    if (!deleted) {
+        return next(buildError("Error al eliminar rol", 404, [`No se encontró el rol con el ID ${id}`]));
+    }
+
+    return successResponse(res, 200, `Rol con ID ${id} eliminado exitosamente`, deleted);
 });
 
 // Gestión de roles (validación de entrada para criterios de arquitectura/RBAC)

--- a/src/models/roles.model.js
+++ b/src/models/roles.model.js
@@ -39,6 +39,241 @@ export const RoleModel = {
   },
 
   /**
+   * Obtiene permisos válidos por código.
+   * @param {Array<string>} permissionCodes
+   * @returns {Promise<Array<{id:number, code:string}>>}
+   */
+  findPermissionsByCodes: async (permissionCodes) => {
+    if (!Array.isArray(permissionCodes) || permissionCodes.length === 0) {
+      return [];
+    }
+
+    const placeholders = permissionCodes.map(() => "?").join(", ");
+    const [rows] = await pool.query(
+      `SELECT id, code FROM permissions WHERE code IN (${placeholders})`,
+      permissionCodes
+    );
+    return rows;
+  },
+
+  /**
+   * Crea un nuevo rol.
+   * @param {{name:string, description?:string}} roleData
+   * @returns {Promise<{id:number,name:string,description:string|null,created_at:Date}|null>}
+   */
+  create: async (roleData) => {
+    const { name, description = null } = roleData;
+
+    const [result] = await pool.query(
+      "INSERT INTO roles (name, description) VALUES (?, ?)",
+      [name, description]
+    );
+
+    return RoleModel.findById(result.insertId);
+  },
+
+  /**
+   * Crea un rol y le asigna permisos en una transacción.
+   * @param {{name:string, description?:string|null, permissions:Array<number>}} roleData
+   * @returns {Promise<{id:number,name:string,description:string|null,created_at:Date}|null>}
+   */
+  createWithPermissions: async (roleData) => {
+    const { name, description = null, permissions = [] } = roleData;
+    const connection = await pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+
+      const [result] = await connection.query(
+        "INSERT INTO roles (name, description) VALUES (?, ?)",
+        [name, description]
+      );
+
+      const roleId = result.insertId;
+
+      if (permissions.length > 0) {
+        const values = permissions.map((permissionId) => [roleId, permissionId]);
+        await connection.query(
+          "INSERT INTO role_permissions (role_id, permission_id) VALUES ?",
+          [values]
+        );
+      }
+
+      await connection.commit();
+
+      const [rows] = await pool.query(
+        "SELECT id, name, description, created_at FROM roles WHERE id = ?",
+        [roleId]
+      );
+
+      return rows[0] || null;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  },
+
+  /**
+   * Actualiza completamente/parcialmente un rol por su ID.
+   * @param {number} id
+   * @param {{name?:string, description?:string}} roleData
+   * @returns {Promise<{id:number,name:string,description:string|null,created_at:Date}|null>}
+   */
+  update: async (id, roleData) => {
+    const fields = [];
+    const values = [];
+
+    if (Object.prototype.hasOwnProperty.call(roleData, "name")) {
+      fields.push("name = ?");
+      values.push(roleData.name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(roleData, "description")) {
+      fields.push("description = ?");
+      values.push(roleData.description);
+    }
+
+    if (fields.length === 0) {
+      return RoleModel.findById(id);
+    }
+
+    values.push(id);
+
+    const [result] = await pool.query(
+      `UPDATE roles SET ${fields.join(", ")} WHERE id = ?`,
+      values
+    );
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return RoleModel.findById(id);
+  },
+
+  /**
+   * Actualiza un rol y opcionalmente sincroniza sus permisos en una transacción.
+   * @param {number} id
+   * @param {{name?:string, description?:string, permissions?:Array<number>}} roleData
+   * @returns {Promise<{id:number,name:string,description:string|null,created_at:Date}|null>}
+   */
+  updateWithPermissions: async (id, roleData) => {
+    const { permissions, ...fieldsData } = roleData;
+    const connection = await pool.getConnection();
+
+    try {
+      await connection.beginTransaction();
+
+      const updateFields = [];
+      const updateValues = [];
+
+      if (Object.prototype.hasOwnProperty.call(fieldsData, "name")) {
+        updateFields.push("name = ?");
+        updateValues.push(fieldsData.name);
+      }
+
+      if (Object.prototype.hasOwnProperty.call(fieldsData, "description")) {
+        updateFields.push("description = ?");
+        updateValues.push(fieldsData.description);
+      }
+
+      if (updateFields.length > 0) {
+        updateValues.push(id);
+        const [updateResult] = await connection.query(
+          `UPDATE roles SET ${updateFields.join(", ")} WHERE id = ?`,
+          updateValues
+        );
+
+        if (updateResult.affectedRows === 0) {
+          await connection.rollback();
+          return null;
+        }
+      } else {
+        const [existingRows] = await connection.query(
+          "SELECT id FROM roles WHERE id = ?",
+          [id]
+        );
+        if (existingRows.length === 0) {
+          await connection.rollback();
+          return null;
+        }
+      }
+
+      if (Array.isArray(permissions)) {
+        await connection.query(
+          "DELETE FROM role_permissions WHERE role_id = ?",
+          [id]
+        );
+
+        if (permissions.length > 0) {
+          const values = permissions.map((permissionId) => [id, permissionId]);
+          await connection.query(
+            "INSERT INTO role_permissions (role_id, permission_id) VALUES ?",
+            [values]
+          );
+        }
+      }
+
+      await connection.commit();
+
+      const [rows] = await pool.query(
+        "SELECT id, name, description, created_at FROM roles WHERE id = ?",
+        [id]
+      );
+
+      return rows[0] || null;
+    } catch (error) {
+      await connection.rollback();
+      throw error;
+    } finally {
+      connection.release();
+    }
+  },
+
+  /**
+   * Elimina un rol por su ID.
+   * @param {number} id
+   * @returns {Promise<{id:number,name:string,description:string|null,created_at:Date}|null>}
+   */
+  delete: async (id) => {
+    const role = await RoleModel.findById(id);
+
+    if (!role) {
+      return null;
+    }
+
+    const [result] = await pool.query("DELETE FROM roles WHERE id = ?", [id]);
+
+    if (result.affectedRows === 0) {
+      return null;
+    }
+
+    return role;
+  },
+
+  /**
+   * Obtiene los permisos asignados a un rol por su ID.
+   * @param {number} roleId
+   * @returns {Promise<Array<{id:number,code:string,description:string|null}>>}
+   */
+  findPermissionsByRoleId: async (roleId) => {
+    const [rows] = await pool.query(
+      `
+      SELECT p.id, p.code, p.description
+      FROM role_permissions rp
+      INNER JOIN permissions p ON p.id = rp.permission_id
+      WHERE rp.role_id = ?
+      ORDER BY p.code ASC
+      `,
+      [roleId]
+    );
+
+    return rows;
+  },
+
+  /**
    * Obtiene los permisos asignados a un usuario por medio de sus roles.
    * Retorna objetos con código y descripción para documentar alcance funcional del permiso.
    * @param {number} userId - ID del usuario.

--- a/src/routes/roles.routes.js
+++ b/src/routes/roles.routes.js
@@ -1,21 +1,63 @@
 import { Router } from 'express';
-import { getRoles, getRoleById, manageRole } from '../controllers/index.js';
+import {
+  getRoles,
+  getRoleById,
+  getRolePermissionsById,
+  createRole,
+  updateRoleById,
+  patchRoleById,
+  deleteRoleById,
+  manageRole
+} from '../controllers/index.js';
 import { validateToken, checkPermission, validateSchema } from '../middlewares/index.js';
-import { roleManagementSchema } from '../schemas/index.js';
+import { roleManagementSchema, roleUpdateSchema, rolePatchSchema } from '../schemas/index.js';
 
 const router = Router();
 
 // Consultar todos los roles
-router.get('/', validateToken, checkPermission('roles:read'), getRoles);
+router.get('/', validateToken, checkPermission('roles.get'), getRoles);
 
 // Consultar un rol específico
-router.get('/:id', validateToken, checkPermission('roles:read'), getRoleById);
+router.get('/:id', validateToken, checkPermission('roles.get'), getRoleById);
+
+// Consultar permisos de un rol específico
+router.get('/:id/permissions', validateToken, checkPermission('roles.get'), getRolePermissionsById);
+
+// Crear un nuevo rol
+router.post(
+  '/',
+  validateToken,
+  checkPermission('roles.manage'),
+  validateSchema(roleManagementSchema),
+  createRole
+);
+
+// Actualizar completamente un rol
+router.put(
+  '/:id',
+  validateToken,
+  checkPermission('roles.manage'),
+  validateSchema(roleUpdateSchema),
+  updateRoleById
+);
+
+// Actualizar parcialmente un rol
+router.patch(
+  '/:id',
+  validateToken,
+  checkPermission('roles.manage'),
+  validateSchema(rolePatchSchema),
+  patchRoleById
+);
+
+// Eliminar un rol
+router.delete('/:id', validateToken, checkPermission('roles.manage'), deleteRoleById);
 
 // Gestión de roles con validación de schema + control RBAC
 router.post(
   '/manage',
   validateToken,
-  checkPermission('roles:manage'),
+  checkPermission('roles.manage'),
   validateSchema(roleManagementSchema),
   manageRole
 );

--- a/src/schemas/roles.schema.js
+++ b/src/schemas/roles.schema.js
@@ -1,26 +1,40 @@
 import { z } from 'zod';
 
+const roleNameSchema = z
+  .string({ message: 'El nombre del rol es obligatorio' })
+  .trim()
+  .min(3, { message: 'El nombre del rol debe tener al menos 3 caracteres' })
+  .max(50, { message: 'El nombre del rol no puede superar 50 caracteres' });
+
+const roleDescriptionSchema = z
+  .string({ message: 'La descripción debe ser texto' })
+  .trim()
+  .max(255, { message: 'La descripción no puede superar 255 caracteres' })
+  .optional()
+  .or(z.literal(''));
+
+const permissionCodeSchema = z
+  .string({ message: 'Cada permiso debe ser texto' })
+  .trim()
+  .min(1, { message: 'El código de permiso no puede estar vacío' })
+  .regex(/^[a-z]+\.[a-z_]+$/, {
+    message: 'El permiso debe seguir el formato recurso.accion',
+  });
+
+const permissionsSchema = z
+  .array(permissionCodeSchema)
+  .min(1, { message: 'Debes enviar al menos un permiso' });
+
 export const roleManagementSchema = z.object({
-  name: z
-    .string({ message: 'El nombre del rol es obligatorio' })
-    .trim()
-    .min(3, { message: 'El nombre del rol debe tener al menos 3 caracteres' })
-    .max(50, { message: 'El nombre del rol no puede superar 50 caracteres' }),
-  description: z
-    .string({ message: 'La descripción debe ser texto' })
-    .trim()
-    .max(255, { message: 'La descripción no puede superar 255 caracteres' })
-    .optional()
-    .or(z.literal('')),
-  permissions: z
-    .array(
-      z
-        .string({ message: 'Cada permiso debe ser texto' })
-        .trim()
-        .min(1, { message: 'El código de permiso no puede estar vacío' })
-        .regex(/^[a-z]+:[a-z_]+$/, {
-          message: 'El permiso debe seguir el formato recurso:accion',
-        })
-    )
-    .min(1, { message: 'Debes enviar al menos un permiso' }),
+  name: roleNameSchema,
+  description: roleDescriptionSchema,
+  permissions: permissionsSchema,
 });
+
+export const roleUpdateSchema = z.object({
+  name: roleNameSchema.optional(),
+  description: roleDescriptionSchema,
+  permissions: permissionsSchema.optional(),
+});
+
+export const rolePatchSchema = roleUpdateSchema;


### PR DESCRIPTION
## Descripción del Cambio
*Este PR consolida y cierra el ciclo de desarrollo del módulo de accesos mediante la implementación del CRUD completo para el recurso de roles y la normalización del formato de permisos (v1.5.7).*

## Tipo de Cambio
- [X] **feat**: Nueva funcionalidad.
- [ ] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #44 

---

## Checklist de Calidad Universal
- [X] **Sincronización:** He actualizado mi rama con `origin/develop` y resolví conflictos.
- [X] **Limpieza:** Sin `console.log`, comentarios de prueba o archivos `.env`.
- [X] **Estándares:** Uso de JSDoc para funciones y nombres de variables en camelCase.

### Validación BACKEND (Si aplica)
- [X] **Endpoints:** He probado las rutas en Postman/Thunder Client y retornan el código HTTP correcto.
- [X] **Validación:** Se implementó manejo de errores (try/catch) y validación de datos de entrada.
- [X] **Modelos:** Los cambios en la base de datos o modelos fueron comunicados al equipo.

---

## Evidencia de Trabajo
*Adjunta un screenshot (Frontend) o un snippet del JSON de respuesta (Backend).*

<img width="1200" height="962" alt="snippet1" src="https://github.com/user-attachments/assets/bfa34bdf-3b01-4c8c-bef1-645a94ac9bf5" />

<img width="1200" height="966" alt="snippets2" src="https://github.com/user-attachments/assets/c0633c58-b9bf-4ba1-bac4-76636404692d" />

<img width="1200" height="967" alt="snippet3" src="https://github.com/user-attachments/assets/8b1528f0-d6e9-485a-b125-a7bce5a72879" />

<img width="1195" height="958" alt="snippet4" src="https://github.com/user-attachments/assets/3671b80f-5e01-4362-9d79-908043ad42a7" />

## Análisis de Impacto
*¿Este cambio requiere que mis compañeros actualicen algo? (Ej: "Deben ejecutar npm install" o "Cambió la URL de la API").*

CAMBIO ROMPIENTE EN ESQUEMAS (Breaking Change): A partir de este cambio, cualquier payload enviado al backend que intente registrar o validar permisos con el formato antiguo recurso:accion (ej. users:read) será rechazado inmediatamente por el validador de esquemas con un error 400 Bad Request. Toda la capa cliente debe enviar los permisos con la estructura de punto (recurso.accion, ej. users.read).